### PR TITLE
Make wishlist icons correspond to wishlist state

### DIFF
--- a/apps/personalization/models.py
+++ b/apps/personalization/models.py
@@ -4,6 +4,8 @@ from django.db import models
 
 class List(models.Model):
     """A wishlist"""
+    # https://stackoverflow.com/questions/3759006/generating-a-non-sequential-id-pk-for-a-django-model
+    # TODO key = models.CharField(max_length=8, unique=True, default=pkgen)
     name = models.CharField(max_length=255)
     owner = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='lists')

--- a/apps/personalization/tests/test_urls.py
+++ b/apps/personalization/tests/test_urls.py
@@ -9,7 +9,7 @@ from ..models import ListItem
 
 
 class ListToggleTests(TestCase):
-    url = reverse('list-toggle')
+    url = reverse('wishlist-toggle')
 
     def setUp(self):
         self.client = Client()

--- a/apps/personalization/tests/test_urls.py
+++ b/apps/personalization/tests/test_urls.py
@@ -8,6 +8,21 @@ from ..factories import ListFactory, UserFactory
 from ..models import ListItem
 
 
+class ListDetailTests(TestCase):
+    url = reverse('wishlist-detail')
+
+    def setUp(self):
+        self.client = Client()
+        self.product = ProductFactory()
+        self.lis = ListFactory()
+        ListItem.objects.create(list=self.lis, product=self.product)
+        self.client.force_login(self.lis.owner)
+
+    def test_returns_list_detail(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.json()['list'], [self.product.pk])
+
+
 class ListToggleTests(TestCase):
     url = reverse('wishlist-toggle')
 

--- a/apps/personalization/tests/test_urls.py
+++ b/apps/personalization/tests/test_urls.py
@@ -20,7 +20,7 @@ class ListDetailTests(TestCase):
 
     def test_returns_list_detail(self):
         response = self.client.get(self.url)
-        self.assertEqual(response.json()['list'], [self.product.pk])
+        self.assertEqual(response.json()['wishlist'], [self.product.pk])
 
 
 class ListToggleTests(TestCase):

--- a/apps/personalization/urls.py
+++ b/apps/personalization/urls.py
@@ -5,5 +5,6 @@ from . import views
 
 
 urlpatterns = [
-    path('api/list/toggle/', login_required(views.ListToggle.as_view()), name='list-toggle'),
+    path('api/list/', login_required(views.WishlistDetail.as_view()), name='wishlist-detail'),
+    path('api/list/toggle/', login_required(views.ListToggle.as_view()), name='wishlist-toggle'),
 ]

--- a/apps/personalization/views.py
+++ b/apps/personalization/views.py
@@ -8,6 +8,9 @@ from apps.tracker.models import Product
 
 
 class WishlistDetail(View):
+    """
+    This might morph into a view that returns all the user state necessary.
+    """
     def get(self, request):
         pass
 

--- a/apps/personalization/views.py
+++ b/apps/personalization/views.py
@@ -12,7 +12,14 @@ class WishlistDetail(View):
     This might morph into a view that returns all the user state necessary.
     """
     def get(self, request):
-        pass
+        try:
+            lis = request.user.lists.earliest('created')
+        except List.DoesNotExist:
+            lis = request.user.lists.create(name='Wishlist')
+
+        return JsonResponse({
+            'list': list(lis.products.all().values_list('pk', flat=True)),
+        })
 
 
 class ListToggle(View):

--- a/apps/personalization/views.py
+++ b/apps/personalization/views.py
@@ -18,7 +18,7 @@ class WishlistDetail(View):
             lis = request.user.lists.create(name='Wishlist')
 
         return JsonResponse({
-            'list': list(lis.products.all().values_list('pk', flat=True)),
+            'wishlist': list(lis.products.all().values_list('pk', flat=True)),
         })
 
 

--- a/apps/tracker/models.py
+++ b/apps/tracker/models.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 class Property(models.Model):
     name = models.CharField(max_length=255, null=True, blank=True)
     url = models.URLField(unique=True)
+    # TODO slug = models.SlugField()
 
     class Meta:
         verbose_name_plural = 'properties'

--- a/apps/tracker/static/app.js
+++ b/apps/tracker/static/app.js
@@ -12,6 +12,15 @@ $.ajaxSetup({
   },
 })
 
+$.ajax('/api/list/', {
+  success: (data) => {
+    data.wishlist.forEach((id) => {
+      $(`.product[data-id=${id}] .product--ui-wishlist`)
+        .addClass('active')
+    })
+  },
+})
+
 $('.product').each(function (idx, el) {
   const $product = $(el)
   $product.on('click', '.product--ui-wishlist', function (e, el) {

--- a/apps/tracker/templates/includes/product.html
+++ b/apps/tracker/templates/includes/product.html
@@ -1,4 +1,4 @@
 <div class="product" data-id="{{ product.pk }}">
   <a href="{{ product.url }}" rel="noreferrer">{{ product }}</a>
-  <a href="{% url 'list-toggle' %}" class="product--ui-wishlist wishlist-loading">❤️</a>
+  <a href="{% url 'wishlist-toggle' %}" class="product--ui-wishlist wishlist-loading">❤️</a>
 </div>


### PR DESCRIPTION
The wishlist toggles now start off active iff they're on the user's wishlist

Done as an AJAX for future cache-ability. Probably going to transition to localStorage later