### PR TITLE
Fix Amazon login used http instead of https

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 cache: pip
 python: "3.7"
+dist: xenial
 services: postgresql
 addons:
   # TravisCI uses 9.2 by default

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
+python: "3.6"  # TravisCI doesn't support 3.7 https://github.com/travis-ci/travis-ci/issues/9815
 cache: pip
-python: "3.7"
-dist: xenial  # required for Python 3.7
-sudo: true  # required for Python 3.7
 services: postgresql
 addons:
   # TravisCI uses 9.2 by default

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 cache: pip
 python: "3.7"
-dist: xenial
+dist: xenial  # required for Python 3.7
+sudo: true  # required for Python 3.7
 services: postgresql
 addons:
   # TravisCI uses 9.2 by default

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 cache: pip
-python: "3.6"
+python: "3.7"
 services: postgresql
 addons:
   # TravisCI uses 9.2 by default

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.7-alpine
 LABEL maintainer="c@crccheck.com"
 
 RUN apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache \
   # psycopg2
   postgresql-dev gcc musl-dev \
   # staticfiles build
-  nodejs make
+  nodejs nodejs-npm make
 
 WORKDIR /app
 COPY requirements.txt /app/requirements.txt

--- a/crap/settings.py
+++ b/crap/settings.py
@@ -94,6 +94,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 AUTHENTICATION_BACKENDS = (
+    # https://sellercentral.amazon.com/home?cor=login_NA&
     'social_core.backends.amazon.AmazonOAuth2',
     'django.contrib.auth.backends.ModelBackend',
 )

--- a/crap/settings.py
+++ b/crap/settings.py
@@ -113,6 +113,8 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.load_extra_data',
     'social_core.pipeline.user.user_details',
 )
+if not DEBUG:
+    SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.0/topics/i18n/

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,4 @@ sqlparse==0.2.4           # via django-debug-toolbar
 text-unidecode==1.2       # via faker
 urllib3==1.23             # via requests
 waitress==1.1.0
-whitenoise==3.3.1
+whitenoise==4.0


### PR DESCRIPTION
If you try to login now, it won't work. The docs explain why: http://python-social-auth-docs.readthedocs.io/en/latest/configuration/settings.html#processing-redirects-and-urlopen

> On projects behind a reverse proxy that uses HTTPS, the redirect URIs can have the wrong schema (http:// instead of https://) if the request lacks the appropriate headers, which might cause errors during the auth process. To force HTTPS in the final URIs set this setting to True

Login seems to be broken locally now too but oh well. Gonna see if this works. Fixes docker build process anyways.

## Verifying the change

In the Virtual environment (`workon crap`):

* `make test`

Need to try this in prod to test the reverse proxy aspect.