### PR TITLE
fix: use historic max price as the price base

### DIFF
--- a/apps/tracker/signals.py
+++ b/apps/tracker/signals.py
@@ -27,10 +27,6 @@ def update_product_pricing(sender, point: TrackPoint, **kwargs) -> None:
         if x.timestamp > one_day_ago:
             day_prices.append(x.price)
 
-    min_prices = [product.min_price] + week_prices
-    min_prices = [x for x in min_prices if x]
-    product.min_price = min(min_prices)
-
     product.last_price = point.price
     product.last_price_check = point.timestamp
 
@@ -47,8 +43,8 @@ def update_product_pricing(sender, point: TrackPoint, **kwargs) -> None:
         max_ever=max_ever,
         min_ever=min_ever,
     )
-    print(all_price_info)
     product.price_base = all_price_info["max_ever"]
+    product.min_price = all_price_info["min_ever"]
 
     product.save()
 

--- a/apps/tracker/signals.py
+++ b/apps/tracker/signals.py
@@ -20,22 +20,23 @@ def update_product_pricing(sender, point: TrackPoint, **kwargs) -> None:
     product = point.product
     point.refresh_from_db()  # make sure `price` isn't a str
 
-    week_prices = product.prices.filter(timestamp__gte=week_ago).values_list('price', flat=True)
-    print(week_prices)
-    product.price_drop_short = max(week_prices) - point.price
-
-    max_ever = Max('price')
-    min_ever = Min('price')
     all_price_info = product.prices.aggregate(
-        count=Count('id'),
-        max_ever=max_ever,
-        min_ever=min_ever,
+        # count=Count('id'),
+        max_ever=Max('price'),
+        min_ever=Min('price'),
     )
     product.price_base = all_price_info["max_ever"]
     product.min_price = all_price_info["min_ever"]
     product.price_drop_long = product.price_base - point.price
     product.last_price = point.price
     product.last_price_check = point.timestamp
+
+    week_price_info = product.prices.filter(timestamp__gte=week_ago).aggregate(
+        # count=Count('id'),
+        max_week=Max('price'),
+    )
+    product.price_drop_short = week_price_info["max_week"] - point.price
+
 
     product.save()
 

--- a/apps/tracker/signals.py
+++ b/apps/tracker/signals.py
@@ -37,7 +37,6 @@ def update_product_pricing(sender, point: TrackPoint, **kwargs) -> None:
     )
     product.price_drop_short = week_price_info["max_week"] - point.price
 
-
     product.save()
 
 

--- a/apps/tracker/signals.py
+++ b/apps/tracker/signals.py
@@ -49,5 +49,5 @@ def update_product_pricing(sender, point: TrackPoint, **kwargs) -> None:
     product.save()
 
 
-track_point_added = Signal(providing_args=['product'])
+track_point_added = Signal(providing_args=['point'])
 track_point_added.connect(update_product_pricing)

--- a/apps/tracker/signals.py
+++ b/apps/tracker/signals.py
@@ -34,7 +34,6 @@ def update_product_pricing(sender, point: TrackPoint, **kwargs) -> None:
         product.price_drop_short = max(day_prices) - point.price
     else:
         product.price_drop_short = 0
-    product.price_drop_long = max(week_prices) - point.price
 
     max_ever = Max('price')
     min_ever = Min('price')
@@ -45,6 +44,7 @@ def update_product_pricing(sender, point: TrackPoint, **kwargs) -> None:
     )
     product.price_base = all_price_info["max_ever"]
     product.min_price = all_price_info["min_ever"]
+    product.price_drop_long = product.price_base - point.price
 
     product.save()
 

--- a/apps/tracker/signals.py
+++ b/apps/tracker/signals.py
@@ -19,21 +19,10 @@ def update_product_pricing(sender, point: TrackPoint, **kwargs) -> None:
 
     product = point.product
     point.refresh_from_db()  # make sure `price` isn't a str
-    week_prices = []
-    day_prices = []
-    one_day_ago = now() - dt.timedelta(days=1, minutes=1)
-    for x in product.prices.filter(timestamp__gte=week_ago):
-        week_prices.append(x.price)
-        if x.timestamp > one_day_ago:
-            day_prices.append(x.price)
 
-    product.last_price = point.price
-    product.last_price_check = point.timestamp
-
-    if day_prices:
-        product.price_drop_short = max(day_prices) - point.price
-    else:
-        product.price_drop_short = 0
+    week_prices = product.prices.filter(timestamp__gte=week_ago).values_list('price', flat=True)
+    print(week_prices)
+    product.price_drop_short = max(week_prices) - point.price
 
     max_ever = Max('price')
     min_ever = Min('price')
@@ -45,6 +34,8 @@ def update_product_pricing(sender, point: TrackPoint, **kwargs) -> None:
     product.price_base = all_price_info["max_ever"]
     product.min_price = all_price_info["min_ever"]
     product.price_drop_long = product.price_base - point.price
+    product.last_price = point.price
+    product.last_price_check = point.timestamp
 
     product.save()
 

--- a/apps/tracker/signals.py
+++ b/apps/tracker/signals.py
@@ -9,7 +9,7 @@ from apps.tracker.models import TrackPoint
 
 # WISHLIST make this async so it doesn't block views.ReceiverView
 # or make it a feature and use the it in the response as user feedback
-def update_product_pricing(sender, point: TrackPoint, **kwargs):
+def update_product_pricing(sender, point: TrackPoint, **kwargs) -> None:
     """
     Denormalize `Product` pricing when a new `TrackPoint` is added
     """

--- a/apps/tracker/tests/test_signals.py
+++ b/apps/tracker/tests/test_signals.py
@@ -34,8 +34,8 @@ class TrackPointTests(TestCase):
         self.assertEqual(product.price_base, 1060)
         self.assertEqual(product.min_price, 1000)
         self.assertEqual(product.last_price, point.price)
-        self.assertEqual(product.price_drop_short, max(0, prices[-2] - prices[-1]))
-        self.assertEqual(product.price_drop_long, max(0, 1060 - prices[-1]))
+        self.assertEqual(product.price_drop_long, 1060 - point.price)
+        self.assertEqual(product.price_drop_short, 1060 - point.price)
 
     def test_base_price_is_higest_seen_price(self):
         product = ProductFactory()

--- a/apps/tracker/tests/test_signals.py
+++ b/apps/tracker/tests/test_signals.py
@@ -36,3 +36,21 @@ class TrackPointTests(TestCase):
         self.assertEqual(product.last_price, point.price)
         self.assertEqual(product.price_drop_short, max(0, prices[-2] - prices[-1]))
         self.assertEqual(product.price_drop_long, max(0, 1060 - prices[-1]))
+
+    def test_base_price_is_higest_seen_price(self):
+        product = ProductFactory()
+        TrackPointFactory(
+            product=product,
+            timestamp=timezone.now() - dt.timedelta(days=30),
+            price=100,
+        )
+        point = TrackPointFactory(
+            product=product,
+            timestamp=timezone.now() - dt.timedelta(days=1),
+            price=60,
+        )
+        track_point_added.send(sender=self, point=point)
+
+        self.assertEqual(product.price_base, 100)
+        self.assertEqual(product.min_price, 60)
+        self.assertEqual(product.last_price, 60)

--- a/apps/tracker/views.py
+++ b/apps/tracker/views.py
@@ -21,7 +21,7 @@ class ReceiverView(View):
         logger.debug(request.body)
         try:
             data = json.loads(request.body)
-        except ValueError as e:
+        except ValueError:
             return HttpResponse(status=400)
 
         hostname = urlparse(data['referrer']).hostname


### PR DESCRIPTION
Currently, we're only looking at price drops that have happened in the past week, but that's way too short. Expand it to use all prices ever seen instead to get a realistic view.

## Verifying the change

In the Virtual environment (`workon crap`):

* `make test`
